### PR TITLE
Remove support for ZERO network

### DIFF
--- a/packages/uniswap/src/types/chains.ts
+++ b/packages/uniswap/src/types/chains.ts
@@ -89,11 +89,11 @@ export type InterfaceChainId = UniverseChainId
 
 export const WEB_SUPPORTED_CHAIN_IDS: InterfaceChainId[] = isProdEnv() ? [
   UniverseChainId.AbstractMainnet,
-  UniverseChainId.Zero,
+  // UniverseChainId.Zero,
   UniverseChainId.Anime,
 ] : [
   UniverseChainId.AbstractMainnet,
-  UniverseChainId.Zero,
+  // UniverseChainId.Zero,
   UniverseChainId.Anime,
 ]
 // [


### PR DESCRIPTION
# ⚠️  DO NOT MERGE UNTIL AUGUST 1 ⚠️

This PR removes support for ZERO network which is being deprecated.